### PR TITLE
Add aarch64 wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,11 @@ matrix:
         - MB_PYTHON_VERSION=3.8
         - NP_BUILD_DEP="1.14.5"
         - NP_TEST_DEP="1.14.5"
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.9
+        - NP_BUILD_DEP="1.19.3"
+        - NP_TEST_DEP="1.19.3"
 
     - os: linux
       env:
@@ -77,6 +82,15 @@ matrix:
       arch: arm64-graviton2
       env:
         - MB_PYTHON_VERSION=3.8
+        - NP_BUILD_DEP="1.19.3"
+        - NP_TEST_DEP="1.19.3"
+        - MB_ML_VER=2014
+        - PLAT=aarch64
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+    - os: linux
+      arch: arm64-graviton2
+      env:
+        - MB_PYTHON_VERSION=3.9
         - NP_BUILD_DEP="1.19.3"
         - NP_TEST_DEP="1.19.3"
         - MB_ML_VER=2014
@@ -104,6 +118,13 @@ matrix:
         - MB_PYTHON_OSX_VER=10.9
         - NP_BUILD_DEP=1.14.5
         - NP_TEST_DEP=1.14.5
+    - os: osx
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=3.9
+        - MB_PYTHON_OSX_VER=10.9
+        - NP_BUILD_DEP=1.19.3
+        - NP_TEST_DEP=1.19.3
 before_install:
     # See:
     # https://github.com/travis-ci/travis-ci/issues/8920#issuecomment-352661024

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,21 +21,14 @@ python: 3.7
 sudo: required
 dist: xenial
 services: docker
+virt: vm
+group: edge
 
 matrix:
-  exclude:
-      # Exclude the default Python 3.7 build
-      - python: 3.7
   include:
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
-        - NP_BUILD_DEP="1.11.3"
-        - NP_TEST_DEP="1.11.3"
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.6
-        - PLAT=i686
         - NP_BUILD_DEP="1.11.3"
         - NP_TEST_DEP="1.11.3"
     - os: linux
@@ -51,10 +44,44 @@ matrix:
 
     - os: linux
       env:
+        - MB_PYTHON_VERSION=3.6
+        - PLAT=i686
+        - NP_BUILD_DEP="1.11.3"
+        - NP_TEST_DEP="1.11.3"
+    - os: linux
+      env:
         - MB_PYTHON_VERSION=3.7
         - PLAT=i686
         - NP_BUILD_DEP="1.14.5"
         - NP_TEST_DEP="1.14.5"
+
+    - os: linux
+      arch: arm64-graviton2
+      env:
+        - MB_PYTHON_VERSION=3.6
+        - NP_BUILD_DEP="1.19.3"
+        - NP_TEST_DEP="1.19.3"
+        - MB_ML_VER=2014
+        - PLAT=aarch64
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+    - os: linux
+      arch: arm64-graviton2
+      env:
+        - MB_PYTHON_VERSION=3.7
+        - NP_BUILD_DEP="1.19.3"
+        - NP_TEST_DEP="1.19.3"
+        - MB_ML_VER=2014
+        - PLAT=aarch64
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+    - os: linux
+      arch: arm64-graviton2
+      env:
+        - MB_PYTHON_VERSION=3.8
+        - NP_BUILD_DEP="1.19.3"
+        - NP_TEST_DEP="1.19.3"
+        - MB_ML_VER=2014
+        - PLAT=aarch64
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
 
     - os: osx
       language: generic


### PR DESCRIPTION
Working build: https://travis-ci.com/github/mattsplats/h5py-wheels/builds/188922579

Related: https://github.com/MacPython/h5py-wheels/issues/11

Notes:
- multibuild was updated for proper aarch64 support
- numpy <1.19 does not contain an aarch64 wheels, could potentially update this to speed things up